### PR TITLE
Update docker-compose.yml

### DIFF
--- a/scripts/vault/docker-compose.yml
+++ b/scripts/vault/docker-compose.yml
@@ -19,17 +19,17 @@ services:
       - ./cache:/home/bitcoin/.bitcoin/testnet3
     restart: unless-stopped
   vault:
-    image: "interlayhq/interbtc-clients:vault-parachain-metadata-testnet-1-5-4"
+    image: "interlayhq/interbtc-clients:vault-parachain-metadata-testnet-1-5-10"
     command:
-      - vault
+      - vault-parachain-metadata-testnet
       - --bitcoin-rpc-url
       - "http://bitcoind:18332"
       - --bitcoin-rpc-user
       - rpcuser
       - --bitcoin-rpc-pass
       - rpcpassword
-      - --keyname
-      - interbtcvault
+      - --keyfile
+      - keyfile.json
       - --keyname
       - interbtcvault
       - --auto-register-with-faucet-url

--- a/scripts/vault/docker-compose.yml
+++ b/scripts/vault/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - --auto-register-with-faucet-url
       - "https://api-testnet.interlay.io/faucet"
       - --btc-parachain-url
-      - "wss://api-testnet.interlay.io/parachain"
+      - "wss://api-testnet.interlay.io:443/parachain"
       - --collateral-currency-id
       - KSM
     environment:


### PR DESCRIPTION
when executing the error "vault" command not found is received, since the binary is /usr/local/bin/vault-parachain-metadata-testnet, the --keyfile parameter is also corrected