### PR TITLE
chore: testnet vaults should now be 1.10.2

### DIFF
--- a/docs/vault/installation.md
+++ b/docs/vault/installation.md
@@ -150,7 +150,7 @@ Download the asset from GitHub:
 #### **Testnet**
 
 ```shell
-wget -O vault https://github.com/interlay/interbtc-clients/releases/download/1.10.1/vault-parachain-metadata-testnet
+wget -O vault https://github.com/interlay/interbtc-clients/releases/download/1.10.2/vault-parachain-metadata-testnet
 ```
 
 #### **Kintsugi**
@@ -196,7 +196,7 @@ cd interbtc-clients
 #### **Testnet**
 
 ```shell
-git checkout 1.10.1
+git checkout 1.10.2
 cargo build --bin vault --features parachain-metadata-testnet
 ```
 

--- a/docs/vault/upgrading.md
+++ b/docs/vault/upgrading.md
@@ -49,7 +49,7 @@ OR terminate the process with `Ctrl+C`.
 #### **Testnet**
 
 ```shell
-wget -O vault https://github.com/interlay/interbtc-clients/releases/download/1.10.1/vault-parachain-metadata-testnet
+wget -O vault https://github.com/interlay/interbtc-clients/releases/download/1.10.2/vault-parachain-metadata-testnet
 ```
 
 #### **Kintsugi**

--- a/scripts/vault/docker-compose.yml
+++ b/scripts/vault/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - ./cache:/home/bitcoin/.bitcoin/testnet3
     restart: unless-stopped
   vault:
-    image: "interlayhq/interbtc-clients:vault-parachain-metadata-testnet-1-10-1"
+    image: "interlayhq/interbtc-clients:vault-parachain-metadata-testnet-1-10-2"
     command:
       - vault-parachain-metadata-testnet
       - --bitcoin-rpc-url


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>