### PR TITLE
bitcoin port 8332; systemd kintsugi-vault.service

### DIFF
--- a/docs/vault/guide.md
+++ b/docs/vault/guide.md
@@ -20,7 +20,7 @@ At the end of this document you will have:
 
 **Web UI**
 
-Go to the Vault tab and click on button next to the `Collateral: X DOT for Y BTC` text (above the Issue Requests table). Then, follow the instructions.
+Go to the Vault tab and click on the `Deposit Collateral` tab. Then follow the instructions.
 
 **interbtc-js library**
 
@@ -41,7 +41,7 @@ await interbtc.vaults.lockAdditionalCollateral(additionalCollateralInPlanck);
 
 **Web UI**
 
-Go to the Vault tab and click on the button next to the `Collateral: X DOT for Y BTC` text (above the Issue Requests table). Then, follow the isntructions.
+Go to the Vault tab and click on the `Withdraw Collateral` button. Then follow the isntructions.
 
 **interbtc-js library**
 

--- a/docs/vault/installation.md
+++ b/docs/vault/installation.md
@@ -315,13 +315,13 @@ Download the systemd service file and a small helper script to install the servi
 
 ```shell
 wget https://raw.githubusercontent.com/interlay/interbtc-docs/master/scripts/vault/setup
-wget https://raw.githubusercontent.com/interlay/interbtc-docs/master/scripts/vault/testnet-vault.service
+wget https://raw.githubusercontent.com/interlay/interbtc-docs/master/scripts/vault/kintsugi-vault.service
 ```
 
 ?> Please adjust the systemd service file to insert your substrate key into the arguments as well as the initial amount of collateral you want to register the Vault with similar to step 5 above. Vim is only used as an example here.
 
 ```shell
-vim testnet-vault.service
+vim kintsugi-vault.service
 ```
 
 Install the service and start it.

--- a/docs/vault/installation.md
+++ b/docs/vault/installation.md
@@ -115,6 +115,8 @@ Please note the following default ports for incoming TCP and JSON-RPC connection
 | Testnet | 18333 | 18332 |
 | Mainnet | 8333  | 8332  |
 
+Once your bitcoin node is running, you can use `nmap -p 8332 127.0.0.1` to verify that the RPC port is open.
+
 ### 2. Start the Bitcoin node
 
 ?> Synchronizing the BTC testnet requires 40GB of storage and the BTC mainnet requires 400GB. Depending on your internet connection, the download time may take anything from hours to days.

--- a/scripts/vault/interlay-vault.service
+++ b/scripts/vault/interlay-vault.service
@@ -6,13 +6,13 @@ After=network.target
 Environment="RUST_LOG=info"
 Type=simple
 ExecStart=/opt/interlay/vault/vault \
-  --bitcoin-rpc-url http://localhost:18332 \
+  --bitcoin-rpc-url http://localhost:8332 \
   --bitcoin-rpc-user rpcuser \
   --bitcoin-rpc-pass rpcpassword \
   --keyfile /opt/interlay/vault/keyfile.json \
   --keyname <INSERT_YOUR_KEYNAME, example: 0x0e5aabe5ff862d66bcba0912bf1b3d4364df0eeec0a8137704e2c16259486a71> \
   --auto-register-with-collateral <INSERT_THE_INITIAL_COLLATERAL, minimum: 300000000000> \
-  --btc-parachain-url 'wss://api.interlay.io:443/parachain' \
+  --btc-parachain-url 'wss://api-interlay.io:443/parachain' \
   --collateral-currency-id=DOT
 Restart=on-failure
 RestartSec=5

--- a/scripts/vault/kintsugi-vault.service
+++ b/scripts/vault/kintsugi-vault.service
@@ -6,7 +6,7 @@ After=network.target
 Environment="RUST_LOG=info"
 Type=simple
 ExecStart=/opt/kintsugi/vault/vault \
-  --bitcoin-rpc-url http://localhost:18332 \
+  --bitcoin-rpc-url http://localhost:8332 \
   --bitcoin-rpc-user rpcuser \
   --bitcoin-rpc-pass rpcpassword \
   --keyfile /opt/kintsugi/vault/keyfile.json \


### PR DESCRIPTION
* `bitcoind` RPC uses port 8332 by default, whereas the bitcoin testnet uses 18332. Some of the *-vault.service files still had 18332 ports listed. Therefore correct those to port 8332.
* Some instructions prompt the user to download the testnet-vault.service file for systemd instead of the kintsugi-vault.service file, which has incorrect parameters.