### PR TITLE
chore: don't merge navbar with sidebar

### DIFF
--- a/docs/_404.md
+++ b/docs/_404.md
@@ -1,0 +1,8 @@
+# Page not found!
+
+Sorry, seems like you found a page that does not exist anymore.
+We would be happy if you'd let us know the issue in our [Discord](https://discord.com/invite/KgCYK3MKSf).
+
+<a class="docs-button util-w100" href="./">
+  Back to the Homepage
+</a>

--- a/docs/_navbar.md
+++ b/docs/_navbar.md
@@ -3,10 +3,8 @@
 * Apps
   * [Interlay](https://app.interlay.io/)
   * [Kintsugi](https://kintsugi.interlay.io)
-  * [Testnet](https://testnet.interlay.io)
-* Claim
-  * [INTR](https://crowdloan.interlay.io)
-  * [KINT](https://claim-kint.interlay.io/)
-* Language
+  * [Interlay Testnet](https://testnet.interlay.io)
+  * [Kintsugi Testnet](https://kintnet.interlay.io)
+* Lang
   * [:uk: English](/)
   * [:cn: 中国](https://info.interlay.io/interlay-wiki/)

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
   <meta name="msapplication-TileColor" content="#ffffff">
   <meta name="msapplication-TileImage" content="_assets/favicon/ms-icon-144x144.png">
   <meta name="theme-color" content="#ffffff">
-</head> 
+</head>
 
 <body>
   <div id="app"></div>
@@ -42,7 +42,8 @@
       loadNavbar: true,
       auto2top: true,
       themeColor: '#1A0A2D',
-      mergeNavbar: true,
+      mergeNavbar: false,
+      notFoundPage: '_404.md',
       name: 'Interlay and Kintsugi Documentation',
       logo: './_assets/img/Interlay_Horizontal_RGB.svg',
       repo: 'https://github.com/interlay/interbtc-docs',


### PR DESCRIPTION
- Don't merge navbar with sidebar. Haven't found an easy option to merge it below the sidebar items and anyway, they would get lost there. Now topbar is shown on mobile as well.
- Due to space reasons, removed the claim button from the navbar so it still looks alright on mobile.
- Added 404 page since we sometimes have outdated links.