### PR TITLE
fix: use the same url for kintsugi-testnet consistently

### DIFF
--- a/scripts/vault/testnet-vault.service
+++ b/scripts/vault/testnet-vault.service
@@ -11,8 +11,8 @@ ExecStart=/opt/testnet/vault/vault \
   --bitcoin-rpc-pass rpcpassword \
   --keyfile /opt/testnet/vault/keyfile.json \
   --keyname <INSERT_YOUR_KEYNAME, example: 0x0e5aabe5ff862d66bcba0912bf1b3d4364df0eeec0a8137704e2c16259486a71> \
-  --btc-parachain-url 'wss://api-testnet.interlay.io/parachain' \
-  --faucet-url 'https://api-testnet.interlay.io/faucet' \
+  --btc-parachain-url 'wss://api-dev-kintsugi.interlay.io:443/parachain' \
+  --faucet-url 'https://api-dev-kintsugi.interlay.io/faucet' \
   --auto-register=KSM=faucet
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
These urls are the ones that are used in the installation guide