### PR TITLE
chore: collators should use --state-cache-size=0 for now

### DIFF
--- a/docs/collator/faq.md
+++ b/docs/collator/faq.md
@@ -13,3 +13,7 @@ Collators earn transaction fees made by users for preparing blocks.
 ### Bootnode with peer id `xxx` is on a different chain
 
 The genesis chain spec is invalid, please download the file specified in the instructions.
+
+### Storage root must match that calculated
+
+The state cache in Substrate has several bugs, nodes [are recommended](https://github.com/paritytech/substrate/issues/9697#issuecomment-982501753) to run with `--state-cache-size=0` set. This will no longer be required after [this change](https://github.com/paritytech/substrate/pull/11407) has been released.

--- a/docs/collator/guide.md
+++ b/docs/collator/guide.md
@@ -38,8 +38,7 @@ Map the directory into a local volume used by the docker container.
 docker run \
   --network host \
   --volume ${PWD}/data:/data \
-  interlayhq/interbtc:interbtc-parachain-1-17-0 \
-  interbtc-parachain \
+  interlayhq/interbtc:1.18.0 \
   --base-path=/data \
   --chain=kintsugi \
   --execution=wasm \
@@ -47,6 +46,7 @@ docker run \
   --unsafe-ws-external \
   --rpc-methods=unsafe \
   --pruning=archive \
+  --state-cache-size=0 \
   -- \
   --rpc-cors=all \
   --no-telemetry \
@@ -54,7 +54,8 @@ docker run \
   --wasm-execution=compiled \
   --database=RocksDb \
   --unsafe-pruning \
-  --pruning=1000
+  --pruning=1000 \
+  --state-cache-size=0
 ```
 
 #### **Interlay**
@@ -63,7 +64,7 @@ docker run \
 docker run \
   --network host \
   --volume ${PWD}/data:/data \
-  interlayhq/interbtc:interbtc-parachain-1-18-0 \
+  interlayhq/interbtc:1.18.0 \
   interbtc-parachain \
   --base-path=/data \
   --chain=interlay \
@@ -72,6 +73,7 @@ docker run \
   --unsafe-ws-external \
   --rpc-methods=unsafe \
   --pruning=archive \
+  --state-cache-size=0 \
   -- \
   --rpc-cors=all \
   --no-telemetry \
@@ -79,7 +81,8 @@ docker run \
   --wasm-execution=compiled \
   --database=RocksDb \
   --unsafe-pruning \
-  --pruning=1000
+  --pruning=1000 \
+  --state-cache-size=0
 ```
 
 <!-- tabs:end -->
@@ -103,6 +106,7 @@ chmod +x interbtc-parachain
   --unsafe-ws-external \
   --rpc-methods=unsafe \
   --pruning=archive \
+  --state-cache-size=0 \
   -- \
   --rpc-cors=all \
   --no-telemetry \
@@ -110,7 +114,8 @@ chmod +x interbtc-parachain
   --wasm-execution=compiled \
   --database=RocksDb \
   --unsafe-pruning \
-  --pruning=1000
+  --pruning=1000 \
+  --state-cache-size=0
 ```
 
 #### **Interlay**
@@ -126,6 +131,7 @@ chmod +x interbtc-parachain
   --unsafe-ws-external \
   --rpc-methods=unsafe \
   --pruning=archive \
+  --state-cache-size=0 \
   -- \
   --rpc-cors=all \
   --no-telemetry \
@@ -133,7 +139,8 @@ chmod +x interbtc-parachain
   --wasm-execution=compiled \
   --database=RocksDb \
   --unsafe-pruning \
-  --pruning=1000
+  --pruning=1000 \
+  --state-cache-size=0
 ```
 
 <!-- tabs:end -->
@@ -182,6 +189,7 @@ cargo build --release
   --unsafe-ws-external \
   --rpc-methods=unsafe \
   --pruning=archive \
+  --state-cache-size=0 \
   -- \
   --rpc-cors=all \
   --no-telemetry \
@@ -189,7 +197,8 @@ cargo build --release
   --wasm-execution=compiled \
   --database=RocksDb \
   --unsafe-pruning \
-  --pruning=1000
+  --pruning=1000 \
+  --state-cache-size=0
 ```
 
 #### **Interlay**
@@ -206,6 +215,7 @@ cargo build --release
   --unsafe-ws-external \
   --rpc-methods=unsafe \
   --pruning=archive \
+  --state-cache-size=0 \
   -- \
   --rpc-cors=all \
   --no-telemetry \
@@ -213,7 +223,8 @@ cargo build --release
   --wasm-execution=compiled \
   --database=RocksDb \
   --unsafe-pruning \
-  --pruning=1000
+  --pruning=1000 \
+  --state-cache-size=0
 ```
 
 <!-- tabs:end -->


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>