### PR TITLE
chore: bump to 1.16.0-hotfix

### DIFF
--- a/docs/vault/installation.md
+++ b/docs/vault/installation.md
@@ -166,25 +166,25 @@ Download the asset from GitHub:
 #### **Testnet (Kintsugi)**
 
 ```shell
-wget -O vault https://github.com/interlay/interbtc-clients/releases/download/1.15.0/vault-parachain-metadata-kintsugi-testnet
+wget -O vault https://github.com/interlay/interbtc-clients/releases/download/1.16.0-hotfix/vault-parachain-metadata-kintsugi-testnet
 ```
 
 #### **Testnet (Interlay)**
 
 ```shell
-wget -O vault https://github.com/interlay/interbtc-clients/releases/download/1.15.0/vault-parachain-metadata-interlay-testnet
+wget -O vault https://github.com/interlay/interbtc-clients/releases/download/1.16.0-hotfix/vault-parachain-metadata-interlay-testnet
 ```
 
 #### **Kintsugi**
 
 ```shell
-wget -O vault https://github.com/interlay/interbtc-clients/releases/download/1.15.0/vault-parachain-metadata-kintsugi
+wget -O vault https://github.com/interlay/interbtc-clients/releases/download/1.16.0-hotfix/vault-parachain-metadata-kintsugi
 ```
 
 #### **Interlay**
 
 ```shell
-wget -O vault https://github.com/interlay/interbtc-clients/releases/download/1.16.0/vault-parachain-metadata-interlay
+wget -O vault https://github.com/interlay/interbtc-clients/releases/download/1.16.0-hotfix/vault-parachain-metadata-interlay
 ```
 
 <!-- tabs:end -->
@@ -224,28 +224,28 @@ cd interbtc-clients
 #### **Testnet (Kintsugi)**
 
 ```shell
-git checkout 1.15.0
+git checkout 1.16.0-hotfix
 cargo build --bin vault --features parachain-metadata-kintsugi-testnet
 ```
 
 #### **Testnet (Interlay)**
 
 ```shell
-git checkout 1.15.0
+git checkout 1.16.0-hotfix
 cargo build --bin vault --features parachain-metadata-interlay-testnet
 ```
 
 #### **Kintsugi**
 
 ```shell
-git checkout 1.15.0
+git checkout 1.16.0-hotfix
 cargo build --bin vault --features parachain-metadata-kintsugi
 ```
 
 #### **Interlay**
 
 ```shell
-git checkout 1.16.0
+git checkout 1.16.0-hotfix
 cargo build --bin vault --features parachain-metadata-interlay
 ```
 

--- a/docs/vault/upgrading.md
+++ b/docs/vault/upgrading.md
@@ -69,7 +69,7 @@ OR terminate the process with `Ctrl+C`.
 #### **Testnet-Kintsugi**
 
 ```shell
-wget -O vault https://github.com/interlay/interbtc-clients/releases/download/1.15.0/vault-parachain-metadata-kintsugi-testnet
+wget -O vault https://github.com/interlay/interbtc-clients/releases/download/1.16.0-hotfix/vault-parachain-metadata-kintsugi-testnet
 
 wget https://raw.githubusercontent.com/interlay/interbtc-docs/master/scripts/vault/setup -O setup
 chmod +x ./setup && sudo ./setup testnet
@@ -78,7 +78,7 @@ chmod +x ./setup && sudo ./setup testnet
 #### **Testnet-Interlay**
 
 ```shell
-wget -O vault https://github.com/interlay/interbtc-clients/releases/download/1.15.0/vault-parachain-metadata-interlay-testnet
+wget -O vault https://github.com/interlay/interbtc-clients/releases/download/1.16.0-hotfix/vault-parachain-metadata-interlay-testnet
 
 wget https://raw.githubusercontent.com/interlay/interbtc-docs/master/scripts/vault/setup -O setup
 chmod +x ./setup && sudo ./setup testnet-interlay
@@ -87,7 +87,7 @@ chmod +x ./setup && sudo ./setup testnet-interlay
 #### **Kintsugi**
 
 ```shell
-wget -O vault https://github.com/interlay/interbtc-clients/releases/download/1.15.0/vault-parachain-metadata-kintsugi
+wget -O vault https://github.com/interlay/interbtc-clients/releases/download/1.16.0-hotfix/vault-parachain-metadata-kintsugi
 
 wget https://raw.githubusercontent.com/interlay/interbtc-docs/master/scripts/vault/setup -O setup
 chmod +x ./setup && sudo ./setup kintsugi


### PR DESCRIPTION
Note that some of these were still on 1.15 - I think that the docs were just outdated and that we can upgrade those to 1.16.0-hotfix as well, right?