### PR TITLE
increase BTC rpcworkqueue for multiple vault clients

### DIFF
--- a/docs/vault/installation.md
+++ b/docs/vault/installation.md
@@ -182,6 +182,18 @@ bitcoind -server -rpcuser=<INSERT_CUSTOM_USERNAME> -rpcpassword=<INSERT_YOUR_PAS
 
 Restart the bitcoin node if it was already running.
 
+
+#### [Optional] Servicing multiple vault clients from the same Bitcoin node
+
+When vault clients start, they parse the bitcoin blockchain via the Bitcoin RPC API. If you are running multiple Kintsugi and/or Interlay vault clients on your computer and the computer is restarted, all of those vault clients might simultaneously start querying the bitcoin node to parse the entire blockchain state for interactions with their vault wallet accounts. This can trigger Bitcoind's `request rejected because http work queue depth exceeded` warning. Vault clients might restart since they're unable to successfully query the Bitcoin RPC endpoint and never be able to complete syncing up to the Bitcoin blockchain. A solution is to increase the depth of the `rpcworkqueue` which by default is set to 16. From anecdotal testing, if you add the following parameter values to your `bitcoin.conf` file (or provide them in your CLI call) then at least seven parallel vault clients can be serviced.
+```
+rpcworkqueue=128
+rpcthreads=128
+rpctimeout=220
+```
+
+If you modify these values and your bitcoin node was already running, restart the bitcoind service.
+
 #### Important Notes
 
 !> Make sure that your Bitcoin RPC port is not available from the internet. You can check this by running e.g., `nmap -p 8332 your.server.ip.address` from another computer. If you expose your Bitcoin RPC port to the internet, you stand at risk of losing all funds including all collateral and BTC locked with the Vault.


### PR DESCRIPTION
## Description
When running multiple clients on the same machine, increase the `rpcworkqueue`, threads, and timeout to help your bitcoin node eventually service all of the parallel requests (and avoid vault clients restarting and failing to sync). This avoids the `request rejected because http work queue depth exceeded` bitcoin RPC warning.

## Notes
When upgrading the Kingstugi vault client from `1.16.0` to `1.17.2`, I ran into the issue that my five restarted Kintsugi vault clients couldn't re-sync to the bitcoin blockchain because their RPC requests to bitcoind would time out. Then the vault clients would restart and start over again. (maybe they should have a back-off algorithm to decrease their request frequency or timeout period if they're experiencing startup failures)
I tried increasing `rpcworkqueue` 16->32 but it wasn't sufficient for my 5 KINT and 2 INTR vaults running on a single machine, all pointing to the same bitcoin node. Instead, I pulled the suggested `128` values from: https://bitcointalk.org/index.php?topic=2715238.msg27913876#msg27913876 and all of the vault clients can now start up simultaneously. So obviously the values could be tuned down to lower values because maybe there's a negative impact on computer resources, but I haven't seen any negative impacts so far so the values were good enough for me and thought I'd share. Therefore in this initial text I only mention them as "anecdotal" values so that they aren't taken to be golden minimum values.