### PR TITLE
Updating bitcoin faucet links 

### DIFF
--- a/docs/guides/wallets-explorers.md
+++ b/docs/guides/wallets-explorers.md
@@ -281,7 +281,6 @@ You can get testnet KINT/INTR for transaction fees by clicking on the faucet lin
 Make sure you have at least some testnet BTC in your wallet.
 You can get testnet BTC by clicking on the faucet link in the top bar of testnet.interlay.io, or from one of the following faucets:
 
-- [https://testnet-faucet.mempool.co/](https://testnet-faucet.mempool.co/)
 - [https://bitcoinfaucet.uo1.net/](https://bitcoinfaucet.uo1.net/)
 - [https://coinfaucet.eu/en/btc-testnet/](https://coinfaucet.eu/en/btc-testnet/)
 - [https://kuttler.eu/en/bitcoin/btc/faucet/](https://kuttler.eu/en/bitcoin/btc/faucet/)


### PR DESCRIPTION
It seems like the first bitcoin faucet that is recommended is no longer available so I removed it. Here is the page error page that pops up in my browser when I attempt to redirect to the link.
![Screen Shot 2023-01-08 at 4 13 41 PM](https://user-images.githubusercontent.com/106350168/211219355-08db0473-f7a3-4a05-a3b1-dfaa6f105603.png)
