### PR TITLE
fix: systemd: restart also after non-failing exit

### DIFF
--- a/scripts/runner/kintsugi-runner.service
+++ b/scripts/runner/kintsugi-runner.service
@@ -18,8 +18,9 @@ ExecStart=/opt/kintsugi/runner/runner \
     --keyname <INSERT_YOUR_KEYNAME, example: 0x0e5aabe5ff862d66bcba0912bf1b3d4364df0eeec0a8137704e2c16259486a71> \
     --auto-register=KSM=3000000000000 \
     --btc-parachain-url 'wss://api-kusama.interlay.io:443/parachain'
-Restart=on-failure
+Restart=always
 RestartSec=5
+StartLimitIntervalSec=0
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/runner/testnet-interlay-runner.service
+++ b/scripts/runner/testnet-interlay-runner.service
@@ -18,8 +18,9 @@ ExecStart=/opt/testnet-interlay/runner/runner \
     --keyname <INSERT_YOUR_KEYNAME, example: 0x0e5aabe5ff862d66bcba0912bf1b3d4364df0eeec0a8137704e2c16259486a71> \
     --auto-register=KSM=3000000000000 \
     --btc-parachain-url 'wss://staging.interlay-dev.interlay.io:443/parachain'
-Restart=on-failure
+Restart=always
 RestartSec=5
+StartLimitIntervalSec=0
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/runner/testnet-kintsugi-runner.service
+++ b/scripts/runner/testnet-kintsugi-runner.service
@@ -18,8 +18,9 @@ ExecStart=/opt/testnet-kintsugi/runner/runner \
     --keyname <INSERT_YOUR_KEYNAME, example: 0x0e5aabe5ff862d66bcba0912bf1b3d4364df0eeec0a8137704e2c16259486a71> \
     --auto-register=KSM=3000000000000 \
     --btc-parachain-url 'wss://api-dev-kintsugi.interlay.io:443/parachain'
-Restart=on-failure
+Restart=always
 RestartSec=5
+StartLimitIntervalSec=0
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/vault/interlay-vault.service
+++ b/scripts/vault/interlay-vault.service
@@ -13,8 +13,9 @@ ExecStart=/opt/interlay/vault/vault \
   --keyname <INSERT_YOUR_KEYNAME, example: 0x0e5aabe5ff862d66bcba0912bf1b3d4364df0eeec0a8137704e2c16259486a71> \
   --btc-parachain-url 'wss://api.interlay.io:443/parachain' \
   --auto-register=DOT=<INSERT_THE_INITIAL_COLLATERAL, minimum: 300000000000>
-Restart=on-failure
+Restart=always
 RestartSec=5
+StartLimitIntervalSec=0
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/vault/kintsugi-vault.service
+++ b/scripts/vault/kintsugi-vault.service
@@ -13,8 +13,9 @@ ExecStart=/opt/kintsugi/vault/vault \
   --keyname <INSERT_YOUR_KEYNAME, example: 0x0e5aabe5ff862d66bcba0912bf1b3d4364df0eeec0a8137704e2c16259486a71> \
   --btc-parachain-url 'wss://api-kusama.interlay.io:443/parachain' \
   --auto-register=KSM=<INSERT_THE_INITIAL_COLLATERAL, minimum: 3000000000000>
-Restart=on-failure
+Restart=always
 RestartSec=5
+StartLimitIntervalSec=0
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/vault/testnet-interlay-vault.service
+++ b/scripts/vault/testnet-interlay-vault.service
@@ -15,8 +15,9 @@ ExecStart=/opt/testnet-interlay/vault/vault \
   --faucet-url 'https://staging.interlay-dev.interlay.io/faucet' \
   --auto-register=DOT=faucet \
   --auto-register=INTR=faucet
-Restart=on-failure
+Restart=always
 RestartSec=5
+StartLimitIntervalSec=0
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/vault/testnet-kintsugi-vault.service
+++ b/scripts/vault/testnet-kintsugi-vault.service
@@ -14,8 +14,8 @@ ExecStart=/opt/testnet-kintsugi/vault/vault \
   --btc-parachain-url 'wss://api-dev-kintsugi.interlay.io:443/parachain' \
   --faucet-url 'https://api-dev-kintsugi.interlay.io/faucet' \
   --auto-register=KSM=faucet
-Restart=on-failure
+Restart=always
 RestartSec=5
-
+StartLimitIntervalSec=0
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The runner sometimes exits with return value 0, in which case systemd does not restart. This pr changes it so it _always_ restarts. I also found [on stackoverflow](https://unix.stackexchange.com/questions/289629/systemd-restart-always-is-not-honored) that systemd gives up after a certain number of retries. To disable that, I also set `StartLimitIntervalSec` to 0 as suggested in that thread. Systemd docs [here](https://www.freedesktop.org/software/systemd/man/systemd.unit.html) for reference