### PR TITLE
update bridge and transfer urls

### DIFF
--- a/docs/guides/assets.md
+++ b/docs/guides/assets.md
@@ -18,7 +18,7 @@ Used in many DeFi applications. On Interlay it can be used for lending and borro
 
 - **From Bitcoin:** If you already have BTC on the bitcoin chain, you can use the [Interlay bridge](https://app.interlay.io/btc) to mint iBTC directly on Interlay. For an extensive guide on how to mint iBTC please see the [docs](/guides/bridge).
 - **From Exchanges**: When minting iBTC you can deposit BTC from a centralized exchange. _Careful: pay close attention to the exact amounts the exchange will send and compare to the amount of BTC you need to deposit into the Vault! These need to be exactly the same for automatic processing, otherwise you will need to manually finalize the mint request via the bridge UI._
-- **From other parachains:** If you already have iBTC on other parachains, use the [btc tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay. iBTC is also available on decentralized exchanges such as: [Pulsar](https://app.stellaswap.com/exchange/swap), [HydraDX](https://app.hydradx.io/#/trade), [Acala](https://apps.acala.network/swap), [Arthswap](https://app.arthswap.org/#/swap), [Parallel](https://app.parallel.fi/swap)
+- **From other parachains:** If you already have iBTC on other parachains, use the [bridge tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay. iBTC is also available on decentralized exchanges such as: [Pulsar](https://app.stellaswap.com/exchange/swap), [HydraDX](https://app.hydradx.io/#/trade), [Acala](https://apps.acala.network/swap), [Arthswap](https://app.arthswap.org/#/swap), [Parallel](https://app.parallel.fi/swap)
 - **From other chains (Ethereum, Solana, Cosmos,..)**: if you are coming from other networks, please see our cross-chain onramp guide below.
 
 ## DOT
@@ -33,10 +33,10 @@ Used in many applications in the ecosystem, such as on-chain governance or DeFi.
 
 **How to get DOT**
 
-- **From centralised exchanges**: Withdraw DOT to Polkadot, then use the [btc tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay. [List of supported exchanges](https://coinmarketcap.com/currencies/polkadot-new/markets/).
-- **From other parachains**: If you already have DOT on a parachain, it first needs to be bridged to the Polkadot relay chain using the cross-chain transfer/xcm-bridging feature of the respective parachain. Once the DOT has been transferred to the relay chain, use the [btc tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay.
+- **From centralised exchanges**: Withdraw DOT to Polkadot, then use the [bridge tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay. [List of supported exchanges](https://coinmarketcap.com/currencies/polkadot-new/markets/).
+- **From other parachains**: If you already have DOT on a parachain, it first needs to be bridged to the Polkadot relay chain using the cross-chain transfer/xcm-bridging feature of the respective parachain. Once the DOT has been transferred to the relay chain, use the [bridge tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay.
 - **From other chains (Ethereum, Solana, Cosmos,..)**: If you are coming from other networks, please see our cross-chain onramp guide below.
-- **From USD/Bank/Credit card**: You can use [Banxa](https://talisman.banxa.com/?coinType=DOT&fiatType=EUR) to buy DOT. You will receive it on the Polkadot relay chain and can then use the [btc tab](https://app.interlay.io/send-and-receive) to bridge it to Interlay.
+- **From USD/Bank/Credit card**: You can use [Banxa](https://talisman.banxa.com/?coinType=DOT&fiatType=EUR) to buy DOT. You will receive it on the Polkadot relay chain and can then use the [bridge tab](https://app.interlay.io/send-and-receive) to bridge it to Interlay.
 
 ## INTR
 
@@ -51,7 +51,7 @@ Used for on-chain governance, to pay for transaction fees or DeFi applications.
 **How to get INTR**
 
 - **From centralised exchanges:** INTR can be bought on [supported exchanges](https://coinmarketcap.com/currencies/interlay-intr/markets/) and directly withdrawn to Interlay by using the exchange’s withdrawal feature.
-- **From other parachains:** If you already have INTR on other parachains, use the [btc tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay. INTR is also available on decentralized exchanges such as: [Pulsar](https://app.stellaswap.com/exchange/swap), [Acala](https://apps.acala.network/swap), [Arthswap](https://app.arthswap.org/#/swap), [Parallel](https://app.parallel.fi/swap)
+- **From other parachains:** If you already have INTR on other parachains, use the [bridge tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay. INTR is also available on decentralized exchanges such as: [Pulsar](https://app.stellaswap.com/exchange/swap), [Acala](https://apps.acala.network/swap), [Arthswap](https://app.arthswap.org/#/swap), [Parallel](https://app.parallel.fi/swap)
 - **From other chains (Ethereum, Solana, Cosmos,..)**: If you are coming from other networks, please see our cross-chain onramp guide below.
 - **From USD/Bank/Credit card (Coming soon)**: Soon will you be able to use [Banxa](https://talisman.banxa.com/?coinType=DOT&fiatType=EUR) to buy INTR. You will receive the purchased tokens directly on the Interlay chain.
 
@@ -67,11 +67,11 @@ Used in many DeFi applications. On Interlay it can be used for lending and borro
 
 **How to get USDT**
 
-- **From centralised exchanges:** USDT can be bought on [supported exchanges](https://coinmarketcap.com/currencies/tether/markets/) and directly withdrawn to Statemint (soon to be renamed to "Polkadot Asset Hub") from [Binance and Bitfinex](https://support.polkadot.network/support/solutions/articles/65000181634-how-to-withdraw-usdt-from-bitfinex-on-statemine). Once you have USDT on Statemint, use the [btc tab](https://app.interlay.io/send-and-receive) in the transfer app to bridge it to Interlay.
+- **From centralised exchanges:** USDT can be bought on [supported exchanges](https://coinmarketcap.com/currencies/tether/markets/) and directly withdrawn to Statemint (soon to be renamed to "Polkadot Asset Hub") from [Binance and Bitfinex](https://support.polkadot.network/support/solutions/articles/65000181634-how-to-withdraw-usdt-from-bitfinex-on-statemine). Once you have USDT on Statemint, use the [bridge tab](https://app.interlay.io/send-and-receive) in the transfer app to bridge it to Interlay.
 
 !> You will need some DOT (recommended: 1 DOT) on Asset Hub to pay for fees. You can send DOT from the Polkadot Relay Chain to Asset Hub using [Talisman](https://app.talisman.xyz/transfer/transport) or [Polkadot.js Teleport](https://support.polkadot.network/support/solutions/articles/65000181119-polkadot-js-ui-how-to-teleport-dot-or-ksm-to-asset-hub). This is a temporary UX issue and will be resolved shortly.
 
-- **From other parachains:** If you already have USDT on other parachains, it first needs to be bridged to the Statemint/Polkadot Asset Hub using the cross-chain transfer/xcm-bridging feature of the respective parachain. Once the USDT has been transferred to Statemint/Polkadot Asset Hub, use the [btc tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay.
+- **From other parachains:** If you already have USDT on other parachains, it first needs to be bridged to the Statemint/Polkadot Asset Hub using the cross-chain transfer/xcm-bridging feature of the respective parachain. Once the USDT has been transferred to Statemint/Polkadot Asset Hub, use the [bridge tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay.
 - **From other chains (Ethereum, Solana, Cosmos,..)**: if you are coming from other networks, please see our cross-chain onramp guide below.
 
 ## Cross-Chain On-Ramp Guide

--- a/docs/guides/assets.md
+++ b/docs/guides/assets.md
@@ -10,33 +10,33 @@ This page explains how to get assets onto Interlay.
 
 iBTC is a fully decentralized, trustless and 1:1 Bitcoin backed asset.
 
-**Use cases:** 
+**Use cases:**
 
 Used in many DeFi applications. On Interlay it can be used for lending and borrowing, for swaps and other products coming soon.
 
 **How to get iBTC**
 
-* **From Bitcoin:** If you already have BTC on the bitcoin chain, you can use the [Interlay bridge](https://app.interlay.io/bridge) to mint iBTC directly on Interlay. For an extensive guide on how to mint iBTC please see the [docs](/guides/bridge).
-* **From Exchanges**: When minting iBTC you can deposit BTC from a centralized exchange. *Careful: pay close attention to the exact amounts the exchange will send and compare to the amount of BTC you need to deposit into the Vault! These need to be exactly the same for automatic processing, otherwise you will need to manually finalize the mint request via the bridge UI.*
-* **From other parachains:** If you already have iBTC on other parachains, use the [bridge tab](https://app.interlay.io/transfer) on the app to bridge it to Interlay. iBTC is also available on decentralized exchanges such as: [Pulsar](https://app.stellaswap.com/exchange/swap), [HydraDX](https://app.hydradx.io/#/trade), [Acala](https://apps.acala.network/swap), [Arthswap](https://app.arthswap.org/#/swap), [Parallel](https://app.parallel.fi/swap)
-* **From other chains (Ethereum, Solana, Cosmos,..)**: if you are coming from other networks, please see our cross-chain onramp guide below.
+- **From Bitcoin:** If you already have BTC on the bitcoin chain, you can use the [Interlay bridge](https://app.interlay.io/btc) to mint iBTC directly on Interlay. For an extensive guide on how to mint iBTC please see the [docs](/guides/bridge).
+- **From Exchanges**: When minting iBTC you can deposit BTC from a centralized exchange. _Careful: pay close attention to the exact amounts the exchange will send and compare to the amount of BTC you need to deposit into the Vault! These need to be exactly the same for automatic processing, otherwise you will need to manually finalize the mint request via the bridge UI._
+- **From other parachains:** If you already have iBTC on other parachains, use the [bridge tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay. iBTC is also available on decentralized exchanges such as: [Pulsar](https://app.stellaswap.com/exchange/swap), [HydraDX](https://app.hydradx.io/#/trade), [Acala](https://apps.acala.network/swap), [Arthswap](https://app.arthswap.org/#/swap), [Parallel](https://app.parallel.fi/swap)
+- **From other chains (Ethereum, Solana, Cosmos,..)**: if you are coming from other networks, please see our cross-chain onramp guide below.
 
 ## DOT
 
-**What is it?** 
+**What is it?**
 
 DOT is the native asset of the Polkadot relay chain.
 
-**Use cases** 
+**Use cases**
 
 Used in many applications in the ecosystem, such as on-chain governance or DeFi. On Interlay it can be used for lending and borrowing, for swaps, or as vault collateral to secure the iBTC bridge.
 
 **How to get DOT**
 
-* **From centralised exchanges**: Withdraw DOT to Polkadot, then use the [bridge tab](https://app.interlay.io/transfer) on the app to bridge it to Interlay. [List of supported exchanges](https://coinmarketcap.com/currencies/polkadot-new/markets/).
-* **From other parachains**: If you already have DOT on a parachain, it first needs to be bridged to the Polkadot relay chain using the cross-chain transfer/xcm-bridging feature of the respective parachain. Once the DOT has been transferred to the relay chain, use the [bridge tab](https://app.interlay.io/transfer) on the app to bridge it to Interlay. 
-* **From other chains (Ethereum, Solana, Cosmos,..)**: If you are coming from other networks, please see our cross-chain onramp guide below.
-* **From USD/Bank/Credit card**: You can use [Banxa](https://talisman.banxa.com/?coinType=DOT&fiatType=EUR) to buy DOT. You will receive it on the Polkadot relay chain and can then use the [bridge tab](https://app.interlay.io/transfer) to bridge it to Interlay.
+- **From centralised exchanges**: Withdraw DOT to Polkadot, then use the [bridge tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay. [List of supported exchanges](https://coinmarketcap.com/currencies/polkadot-new/markets/).
+- **From other parachains**: If you already have DOT on a parachain, it first needs to be bridged to the Polkadot relay chain using the cross-chain transfer/xcm-bridging feature of the respective parachain. Once the DOT has been transferred to the relay chain, use the [bridge tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay.
+- **From other chains (Ethereum, Solana, Cosmos,..)**: If you are coming from other networks, please see our cross-chain onramp guide below.
+- **From USD/Bank/Credit card**: You can use [Banxa](https://talisman.banxa.com/?coinType=DOT&fiatType=EUR) to buy DOT. You will receive it on the Polkadot relay chain and can then use the [bridge tab](https://app.interlay.io/send-and-receive) to bridge it to Interlay.
 
 ## INTR
 
@@ -44,16 +44,16 @@ Used in many applications in the ecosystem, such as on-chain governance or DeFi.
 
 INTR is the native asset of the Interlay parachain.
 
-**Use cases:** 
+**Use cases:**
 
-Used for on-chain governance, to pay for transaction fees or DeFi applications. 
+Used for on-chain governance, to pay for transaction fees or DeFi applications.
 
 **How to get INTR**
 
-* **From centralised exchanges:** INTR can be bought on [supported exchanges](https://coinmarketcap.com/currencies/interlay-intr/markets/) and directly withdrawn to Interlay by using the exchange’s withdrawal feature.
-* **From other parachains:** If you already have INTR on other parachains, use the [bridge tab](https://app.interlay.io/transfer) on the app to bridge it to Interlay. INTR is also available on decentralized exchanges such as: [Pulsar](https://app.stellaswap.com/exchange/swap), [Acala](https://apps.acala.network/swap), [Arthswap](https://app.arthswap.org/#/swap), [Parallel](https://app.parallel.fi/swap)
-* **From other chains (Ethereum, Solana, Cosmos,..)**: If you are coming from other networks, please see our cross-chain onramp guide below.
-* **From USD/Bank/Credit card (Coming soon)**: Soon will you be able to use [Banxa](https://talisman.banxa.com/?coinType=DOT&fiatType=EUR) to buy INTR. You will receive the purchased tokens directly on the Interlay chain.
+- **From centralised exchanges:** INTR can be bought on [supported exchanges](https://coinmarketcap.com/currencies/interlay-intr/markets/) and directly withdrawn to Interlay by using the exchange’s withdrawal feature.
+- **From other parachains:** If you already have INTR on other parachains, use the [bridge tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay. INTR is also available on decentralized exchanges such as: [Pulsar](https://app.stellaswap.com/exchange/swap), [Acala](https://apps.acala.network/swap), [Arthswap](https://app.arthswap.org/#/swap), [Parallel](https://app.parallel.fi/swap)
+- **From other chains (Ethereum, Solana, Cosmos,..)**: If you are coming from other networks, please see our cross-chain onramp guide below.
+- **From USD/Bank/Credit card (Coming soon)**: Soon will you be able to use [Banxa](https://talisman.banxa.com/?coinType=DOT&fiatType=EUR) to buy INTR. You will receive the purchased tokens directly on the Interlay chain.
 
 ## USDT
 
@@ -61,21 +61,18 @@ Used for on-chain governance, to pay for transaction fees or DeFi applications.
 
 USDT is a USD pegged stable coin issued by Tether.
 
-**Use cases:** 
+**Use cases:**
 
 Used in many DeFi applications. On Interlay it can be used for lending and borrowing, for swaps, or as vault collateral to secure the iBTC bridge.
 
 **How to get USDT**
 
-* **From centralised exchanges:** USDT can be bought on [supported exchanges](https://coinmarketcap.com/currencies/tether/markets/) and directly withdrawn to Statemint (soon to be renamed to "Polkadot Asset Hub") from [Binance and Bitfinex](https://support.polkadot.network/support/solutions/articles/65000181634-how-to-withdraw-usdt-from-bitfinex-on-statemine). Once you have USDT on Statemint, use the [bridge tab](https://app.interlay.io/transfer) in the transfer app to bridge it to Interlay.
+- **From centralised exchanges:** USDT can be bought on [supported exchanges](https://coinmarketcap.com/currencies/tether/markets/) and directly withdrawn to Statemint (soon to be renamed to "Polkadot Asset Hub") from [Binance and Bitfinex](https://support.polkadot.network/support/solutions/articles/65000181634-how-to-withdraw-usdt-from-bitfinex-on-statemine). Once you have USDT on Statemint, use the [bridge tab](https://app.interlay.io/send-and-receive) in the transfer app to bridge it to Interlay.
 
-!> You will need some DOT (recommended: 1 DOT) on Asset Hub to pay for fees. You can send DOT from the Polkadot Relay Chain to Asset Hub using [Talisman]( https://app.talisman.xyz/transfer/transport) or [Polkadot.js Teleport](https://support.polkadot.network/support/solutions/articles/65000181119-polkadot-js-ui-how-to-teleport-dot-or-ksm-to-asset-hub). This is a temporary UX issue and will be resolved shortly. 
+!> You will need some DOT (recommended: 1 DOT) on Asset Hub to pay for fees. You can send DOT from the Polkadot Relay Chain to Asset Hub using [Talisman](https://app.talisman.xyz/transfer/transport) or [Polkadot.js Teleport](https://support.polkadot.network/support/solutions/articles/65000181119-polkadot-js-ui-how-to-teleport-dot-or-ksm-to-asset-hub). This is a temporary UX issue and will be resolved shortly.
 
-* **From other parachains:** If you already have USDT on other parachains, it first needs to be bridged to the Statemint/Polkadot Asset Hub using the cross-chain transfer/xcm-bridging feature of the respective parachain. Once the USDT has been transferred to Statemint/Polkadot Asset Hub, use the [bridge tab](https://app.interlay.io/transfer) on the app to bridge it to Interlay. 
-* **From other chains (Ethereum, Solana, Cosmos,..)**: if you are coming from other networks, please see our cross-chain onramp guide below.
-
-
-
+- **From other parachains:** If you already have USDT on other parachains, it first needs to be bridged to the Statemint/Polkadot Asset Hub using the cross-chain transfer/xcm-bridging feature of the respective parachain. Once the USDT has been transferred to Statemint/Polkadot Asset Hub, use the [bridge tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay.
+- **From other chains (Ethereum, Solana, Cosmos,..)**: if you are coming from other networks, please see our cross-chain onramp guide below.
 
 ## Cross-Chain On-Ramp Guide
 
@@ -83,12 +80,12 @@ If you have assets on other chains, such as Ethereum, you can use existing crypt
 
 ?> Attention: Mentions of 3rd party platforms below are **not** endorsements and you should due proper due diligence before using any of these products.
 
-
 ### Swap for BTC and mint IBTC
 
 One of the easiest ways to get your assets into Interlay is to swap them for BTC and then mint iBTC.
 
 Here are some platforms that support crypto-BTC swaps.
+
 - [Thorchain](https://thorchain.org/swap)
 - [Shapeshift](https://shapeshift.com/)
 - [Sideshift.ai](https://sideshift.ai/eth/btc)

--- a/docs/guides/assets.md
+++ b/docs/guides/assets.md
@@ -18,7 +18,7 @@ Used in many DeFi applications. On Interlay it can be used for lending and borro
 
 - **From Bitcoin:** If you already have BTC on the bitcoin chain, you can use the [Interlay bridge](https://app.interlay.io/btc) to mint iBTC directly on Interlay. For an extensive guide on how to mint iBTC please see the [docs](/guides/bridge).
 - **From Exchanges**: When minting iBTC you can deposit BTC from a centralized exchange. _Careful: pay close attention to the exact amounts the exchange will send and compare to the amount of BTC you need to deposit into the Vault! These need to be exactly the same for automatic processing, otherwise you will need to manually finalize the mint request via the bridge UI._
-- **From other parachains:** If you already have iBTC on other parachains, use the [bridge tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay. iBTC is also available on decentralized exchanges such as: [Pulsar](https://app.stellaswap.com/exchange/swap), [HydraDX](https://app.hydradx.io/#/trade), [Acala](https://apps.acala.network/swap), [Arthswap](https://app.arthswap.org/#/swap), [Parallel](https://app.parallel.fi/swap)
+- **From other parachains:** If you already have iBTC on other parachains, use the [btc tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay. iBTC is also available on decentralized exchanges such as: [Pulsar](https://app.stellaswap.com/exchange/swap), [HydraDX](https://app.hydradx.io/#/trade), [Acala](https://apps.acala.network/swap), [Arthswap](https://app.arthswap.org/#/swap), [Parallel](https://app.parallel.fi/swap)
 - **From other chains (Ethereum, Solana, Cosmos,..)**: if you are coming from other networks, please see our cross-chain onramp guide below.
 
 ## DOT
@@ -33,10 +33,10 @@ Used in many applications in the ecosystem, such as on-chain governance or DeFi.
 
 **How to get DOT**
 
-- **From centralised exchanges**: Withdraw DOT to Polkadot, then use the [bridge tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay. [List of supported exchanges](https://coinmarketcap.com/currencies/polkadot-new/markets/).
-- **From other parachains**: If you already have DOT on a parachain, it first needs to be bridged to the Polkadot relay chain using the cross-chain transfer/xcm-bridging feature of the respective parachain. Once the DOT has been transferred to the relay chain, use the [bridge tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay.
+- **From centralised exchanges**: Withdraw DOT to Polkadot, then use the [btc tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay. [List of supported exchanges](https://coinmarketcap.com/currencies/polkadot-new/markets/).
+- **From other parachains**: If you already have DOT on a parachain, it first needs to be bridged to the Polkadot relay chain using the cross-chain transfer/xcm-bridging feature of the respective parachain. Once the DOT has been transferred to the relay chain, use the [btc tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay.
 - **From other chains (Ethereum, Solana, Cosmos,..)**: If you are coming from other networks, please see our cross-chain onramp guide below.
-- **From USD/Bank/Credit card**: You can use [Banxa](https://talisman.banxa.com/?coinType=DOT&fiatType=EUR) to buy DOT. You will receive it on the Polkadot relay chain and can then use the [bridge tab](https://app.interlay.io/send-and-receive) to bridge it to Interlay.
+- **From USD/Bank/Credit card**: You can use [Banxa](https://talisman.banxa.com/?coinType=DOT&fiatType=EUR) to buy DOT. You will receive it on the Polkadot relay chain and can then use the [btc tab](https://app.interlay.io/send-and-receive) to bridge it to Interlay.
 
 ## INTR
 
@@ -51,7 +51,7 @@ Used for on-chain governance, to pay for transaction fees or DeFi applications.
 **How to get INTR**
 
 - **From centralised exchanges:** INTR can be bought on [supported exchanges](https://coinmarketcap.com/currencies/interlay-intr/markets/) and directly withdrawn to Interlay by using the exchange’s withdrawal feature.
-- **From other parachains:** If you already have INTR on other parachains, use the [bridge tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay. INTR is also available on decentralized exchanges such as: [Pulsar](https://app.stellaswap.com/exchange/swap), [Acala](https://apps.acala.network/swap), [Arthswap](https://app.arthswap.org/#/swap), [Parallel](https://app.parallel.fi/swap)
+- **From other parachains:** If you already have INTR on other parachains, use the [btc tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay. INTR is also available on decentralized exchanges such as: [Pulsar](https://app.stellaswap.com/exchange/swap), [Acala](https://apps.acala.network/swap), [Arthswap](https://app.arthswap.org/#/swap), [Parallel](https://app.parallel.fi/swap)
 - **From other chains (Ethereum, Solana, Cosmos,..)**: If you are coming from other networks, please see our cross-chain onramp guide below.
 - **From USD/Bank/Credit card (Coming soon)**: Soon will you be able to use [Banxa](https://talisman.banxa.com/?coinType=DOT&fiatType=EUR) to buy INTR. You will receive the purchased tokens directly on the Interlay chain.
 
@@ -67,11 +67,11 @@ Used in many DeFi applications. On Interlay it can be used for lending and borro
 
 **How to get USDT**
 
-- **From centralised exchanges:** USDT can be bought on [supported exchanges](https://coinmarketcap.com/currencies/tether/markets/) and directly withdrawn to Statemint (soon to be renamed to "Polkadot Asset Hub") from [Binance and Bitfinex](https://support.polkadot.network/support/solutions/articles/65000181634-how-to-withdraw-usdt-from-bitfinex-on-statemine). Once you have USDT on Statemint, use the [bridge tab](https://app.interlay.io/send-and-receive) in the transfer app to bridge it to Interlay.
+- **From centralised exchanges:** USDT can be bought on [supported exchanges](https://coinmarketcap.com/currencies/tether/markets/) and directly withdrawn to Statemint (soon to be renamed to "Polkadot Asset Hub") from [Binance and Bitfinex](https://support.polkadot.network/support/solutions/articles/65000181634-how-to-withdraw-usdt-from-bitfinex-on-statemine). Once you have USDT on Statemint, use the [btc tab](https://app.interlay.io/send-and-receive) in the transfer app to bridge it to Interlay.
 
 !> You will need some DOT (recommended: 1 DOT) on Asset Hub to pay for fees. You can send DOT from the Polkadot Relay Chain to Asset Hub using [Talisman](https://app.talisman.xyz/transfer/transport) or [Polkadot.js Teleport](https://support.polkadot.network/support/solutions/articles/65000181119-polkadot-js-ui-how-to-teleport-dot-or-ksm-to-asset-hub). This is a temporary UX issue and will be resolved shortly.
 
-- **From other parachains:** If you already have USDT on other parachains, it first needs to be bridged to the Statemint/Polkadot Asset Hub using the cross-chain transfer/xcm-bridging feature of the respective parachain. Once the USDT has been transferred to Statemint/Polkadot Asset Hub, use the [bridge tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay.
+- **From other parachains:** If you already have USDT on other parachains, it first needs to be bridged to the Statemint/Polkadot Asset Hub using the cross-chain transfer/xcm-bridging feature of the respective parachain. Once the USDT has been transferred to Statemint/Polkadot Asset Hub, use the [btc tab](https://app.interlay.io/send-and-receive) on the app to bridge it to Interlay.
 - **From other chains (Ethereum, Solana, Cosmos,..)**: if you are coming from other networks, please see our cross-chain onramp guide below.
 
 ## Cross-Chain On-Ramp Guide

--- a/docs/guides/bridge.md
+++ b/docs/guides/bridge.md
@@ -31,11 +31,11 @@ Make sure you have the required [polkadot-js extension and a Bitcoin wallet](gui
 
 ##### **Testnet-Kintsugi**
 
-[testnet.interlay.io/bridge](https://kintnet.interlay.io/bridge)
+[kintnet.interlay.io/bridge](https://kintnet.interlay.io/btc)
 
 ##### **Testnet-Interlay**
 
-[testnet.interlay.io/bridge](https://testnet.interlay.io/bridge)
+[testnet.interlay.io/btc](https://testnet.interlay.io/btc)
 
 <!-- tabs:end -->
 

--- a/docs/guides/bridge.md
+++ b/docs/guides/bridge.md
@@ -17,7 +17,7 @@ Make sure you have the required [polkadot-js extension and a Bitcoin wallet](gui
 
 ### Issue IBTC/KBTC
 
-#### 1. Go to the bridge page.
+#### 1. Go to the btc page.
 
 <!-- tabs:start -->
 
@@ -206,7 +206,7 @@ At the end of this guide you will have:
 
 ### Redeem IBTC/KBTC
 
-#### 1. Go to the bridge page.
+#### 1. Go to the btc page.
 
 <!-- tabs:start -->
 

--- a/docs/guides/bridge.md
+++ b/docs/guides/bridge.md
@@ -23,11 +23,11 @@ Make sure you have the required [polkadot-js extension and a Bitcoin wallet](gui
 
 ##### **Interlay**
 
-[app.interlay.io/bridge](https://app.interlay.io/bridge)
+[app.interlay.io/btc](https://app.interlay.io/btc)
 
 ##### **Kintsugi**
 
-[kintsugi.interlay.io/bridge](https://kintsugi.interlay.io/bridge)
+[kintsugi.interlay.io/btc](https://kintsugi.interlay.io/btc)
 
 ##### **Testnet-Kintsugi**
 
@@ -212,11 +212,11 @@ At the end of this guide you will have:
 
 ##### **Interlay**
 
-[app.interlay.io/bridge](https://app.interlay.io/bridge)
+[app.interlay.io/btc](https://app.interlay.io/btc)
 
 ##### **Kintsugi**
 
-[kintsugi.interlay.io/bridge](https://kintsugi.interlay.io/bridge)
+[kintsugi.interlay.io/btc](https://kintsugi.interlay.io/btc)
 
 ##### **Testnet-Kintsugi**
 

--- a/docs/guides/transfers.md
+++ b/docs/guides/transfers.md
@@ -28,7 +28,7 @@
 
 ### Transfer to another address
 
-1. Go to the Transfer page on the app. Make sure you allow polkadot.js to connect to the website.
+1. Go to the Send and Receive page on the app. Make sure you allow polkadot.js to connect to the website.
 2. Select the token you would like to transfer, e.g., DOT, IBTC, INTR, KSM, KBTC, or KINT.
 3. Your available balance is shown on top of the amount input field.
 4. Enter the address of the recipient. This can be in any supported Polkadot address format and will automatically be converted to the Interlay/Kintsugi address format for the transfer.

--- a/docs/guides/transfers.md
+++ b/docs/guides/transfers.md
@@ -42,11 +42,11 @@
 
 #### **Interlay**
 
-[https://app.interlay.io/send-and-receive?tab=crossChainTransfer](https://app.interlay.io/send-and-receive?tab=crossChainTransfer)
+[https://app.interlay.io/send-and-receive?tab=bridge](https://app.interlay.io/send-and-receive?tab=bridge)
 
 #### **Kintsugi**
 
-[https://kintsugi.interlay.io/send-and-receive?tab=crossChainTransfer](https://kintsugi.interlay.io/send-and-receive?tab=crossChainTransfer)
+[https://kintsugi.interlay.io/send-and-receive?tab=bridge](https://kintsugi.interlay.io/send-and-receive?tab=bridge)
 
 <!-- tabs:end -->
 

--- a/docs/guides/transfers.md
+++ b/docs/guides/transfers.md
@@ -7,13 +7,14 @@
 ## Using the App
 
 <!-- tabs:start -->
+
 #### **Interlay**
 
-[https://app.interlay.io/transfer](https://app.interlay.io/transfer)
+[https://app.interlay.io/send-and-receive](https://app.interlay.io/send-and-receive)
 
 #### **Kintsugi**
 
-[kintsugi.interlay.io/transfer](https://kintsugi.interlay.io/transfer)
+[kintsugi.interlay.io/send-and-receive](https://kintsugi.interlay.io/send-and-receive)
 
 #### **Testnet-Kintsugi**
 
@@ -38,13 +39,14 @@
 ?> At present we support transferring KSM between Kusama and Kintsugi, DOT between Polkadot and Interlay and USDT between Statemine/Statemint and Kintsugi/Interlay.
 
 <!-- tabs:start -->
+
 #### **Interlay**
 
-[https://app.interlay.io/transfer?tab=crossChainTransfer](https://app.interlay.io/transfer?tab=crossChainTransfer)
+[https://app.interlay.io/send-and-receive?tab=crossChainTransfer](https://app.interlay.io/send-and-receive?tab=crossChainTransfer)
 
 #### **Kintsugi**
 
-[https://kintsugi.interlay.io/transfer?tab=crossChainTransfer](https://kintsugi.interlay.io/transfer?tab=crossChainTransfer)
+[https://kintsugi.interlay.io/send-and-receive?tab=crossChainTransfer](https://kintsugi.interlay.io/send-and-receive?tab=crossChainTransfer)
 
 <!-- tabs:end -->
 
@@ -56,6 +58,7 @@ Click to view cross chain transfer
 </summary>
 
 ![Cross-chain-transfer](../_assets/img/guide/to-kintsugi-cross-chain-transfer.png)
+
 </details>
 
 0. To transfer any token to Interlay/Kintsugi, please make sure that you do have a sufficient balance on the origin chain to pay for transaction fees.
@@ -74,6 +77,7 @@ Click to view cross chain transfer
 </summary>
 
 ![Cross-chain-transfer](../_assets/img/guide/from-kintsugi-cross-chain-transfer.png)
+
 </details>
 
 0. To transfer any token from Interlay/Kintsugi, please make sure that you do have a sufficient balance of INTR/KINT to pay for transaction fees.
@@ -86,12 +90,13 @@ Click to view cross chain transfer
 7. After the transfer has been made, your available token balance at the top of the page should decrease by the amount that has been transferred. If you want to check your balance on the target chain, you can do this on [Subscan](https://www.subscan.io/), but you can also set the "from" chain value to Polkadot/Kusama (as if you were making a transfer in the other direction) to see the updated balance above the amount field. This may not update immediately, and you may need to refresh the page to see the current balance.
 
 #### How to send USDT to Interlay/Kintsugi
+
 1. Ensure you have USDT in Statemint (Polkadot) or Statemine (Kusama) - see the Polkadot official guide on [how to get USDT from Bitfinex](https://support.polkadot.network/support/solutions/articles/65000181634-how-to-withdraw-usdt-from-bitfinex-on-statemine)
 2. Follow the guide on how to transfer funds [To Interlay/Kintsugi](#to-interlaykintsugi)
 3. (Optional) To check your USDT balance on Statemint or Statemine you can follow the first steps of the Polkadot official guide on [How to Transfer Tether (USDT) on Statemine](https://support.polkadot.network/support/solutions/articles/65000181118)
 
-
 ## Polkadot.js Developer Tab (Advanced)
+
 <details>
 <summary>
 Click to expand
@@ -118,7 +123,6 @@ Click to expand
 7. Enter the amount **in pico KINT (1 KINT = 1,000,000,000,000 pico KINT)**.
 
 8. Press "Sign Transaction". In the opened modal, enter your account password, and then click "Sign and Submit".
-
 
 You will see a green success message after 10-20 seconds in the top right if the transfer was successful.
 


### PR DESCRIPTION
Update documentation to user new urls for btc (previously bridge) and send-and-receive (previously transfer)